### PR TITLE
feat: add login logout

### DIFF
--- a/environments/.env.development
+++ b/environments/.env.development
@@ -1,5 +1,7 @@
 VITE_MOCK_API_HOST=https://jsonplaceholder.typicode.com
 VITE_LOCAL_MOCK_API_HOST=https://jsonplaceholder.typicode.com
+VITE_LOGIN_URL=https://cwafightfish.auth.ap-southeast-1.amazoncognito.com/oauth2/authorize?client_id=292njj2ilaqh60ff99pb9smns6&response_type=token&scope=bettafish-id%2Fget+bettafish-id%2Fpost&redirect_uri=https%3A%2F%2Fd1pijhzuzdx8b9.cloudfront.net%2Fexternal%2Findex.html
+VITE_LOGOUT_URL=https://cwafightfish.auth.ap-southeast-1.amazoncognito.com/logout?client_id=292njj2ilaqh60ff99pb9smns6&logout_uri=https://cwafightfish.auth.ap-southeast-1.amazoncognito.com/oauth2/authorize?client_id=292njj2ilaqh60ff99pb9smns6&response_type=token&scope=bettafish-id%2Fget+bettafish-id%2Fpost&redirect_uri=https%3A%2F%2Fd1pijhzuzdx8b9.cloudfront.net%2Fexternal/index.html
 VITE_AWS_HOST_PREFIX=/default
 VITE_AWS_CHECK_AUTHORIZE=https://h8lanmxqp8.execute-api.ap-southeast-1.amazonaws.com
 VITE_AWS_NO_AUTH_FISH_TYPE_HOST=https://h8lanmxqp8.execute-api.ap-southeast-1.amazonaws.com

--- a/environments/.env.mock
+++ b/environments/.env.mock
@@ -1,6 +1,8 @@
 # `/default` path can let vite-plugin-mock replace request as mockData in "DEV" mode
 VITE_MOCK_API_HOST=/default
 VITE_LOCAL_MOCK_API_HOST=/default
+VITE_LOGIN_URL=login/
+VITE_LOGOUT_URL=login/
 VITE_AWS_HOST_PREFIX=/default
 VITE_AWS_CHECK_AUTHORIZE=
 VITE_AWS_NO_AUTH_FISH_TYPE_HOST=

--- a/environments/.env.production
+++ b/environments/.env.production
@@ -1,5 +1,7 @@
 VITE_MOCK_API_HOST=https://jsonplaceholder.typicode.com
 VITE_LOCAL_MOCK_API_HOST=https://jsonplaceholder.typicode.com
+VITE_LOGIN_URL=https://cwafightfish.auth.ap-southeast-1.amazoncognito.com/oauth2/authorize?client_id=292njj2ilaqh60ff99pb9smns6&response_type=token&scope=bettafish-id%2Fget+bettafish-id%2Fpost&redirect_uri=https%3A%2F%2Fd1pijhzuzdx8b9.cloudfront.net%2Fexternal%2Findex.html
+VITE_LOGOUT_URL=https://cwafightfish.auth.ap-southeast-1.amazoncognito.com/logout?client_id=292njj2ilaqh60ff99pb9smns6&logout_uri=https://cwafightfish.auth.ap-southeast-1.amazoncognito.com/oauth2/authorize?client_id=292njj2ilaqh60ff99pb9smns6&response_type=token&scope=bettafish-id%2Fget+bettafish-id%2Fpost&redirect_uri=https%3A%2F%2Fd1pijhzuzdx8b9.cloudfront.net%2Fexternal/index.html
 VITE_AWS_HOST_PREFIX=/default
 VITE_AWS_CHECK_AUTHORIZE=https://h8lanmxqp8.execute-api.ap-southeast-1.amazonaws.com
 VITE_AWS_NO_AUTH_FISH_TYPE_HOST=https://h8lanmxqp8.execute-api.ap-southeast-1.amazonaws.com

--- a/src/components/NavBar/index.jsx
+++ b/src/components/NavBar/index.jsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { get, keyBy } from 'lodash-es'
 import useOnInit from '../../hooks/useOnInit'
 
+const logoutUrl = import.meta.env.VITE_LOGOUT_URL
 const langs = [
   { label: '中文繁體', value: 'zh-TW' },
   { label: 'English', value: 'en' },
@@ -33,7 +34,13 @@ const Logout = (props) => {
 
   return (
     <a
-      href={window.location.href.replace(window.location.pathname, `${window.APP_BASENAME}/`)}
+      href={
+        window.IS_MOCK
+          ? window.location.href
+            .replace(window.location.pathname, `${window.APP_BASENAME}/${logoutUrl}`)
+            .replace(window.location.search, '')
+          : logoutUrl
+    }
       className='btn btn-ghost'
     >
       {children}

--- a/src/components/Router/index.jsx
+++ b/src/components/Router/index.jsx
@@ -13,6 +13,7 @@ import Layout from './Layout'
 import NavBar from '../NavBar'
 import 'react-loading-skeleton/dist/skeleton.css'
 
+const loginUrl = import.meta.env.VITE_LOGIN_URL
 const host = getApiHost('VITE_AWS_CHECK_AUTHORIZE')
 const awsHostPrefix = import.meta.env.VITE_AWS_HOST_PREFIX
 const authConfig = {
@@ -48,6 +49,9 @@ const Router = (props) => {
         return isAuthRoutes
           ? fetcher(authConfig).catch((e) => {
             console.log(e)
+            setTimeout(() => {
+              window.location.href = loginUrl
+            }, 3000)
             return { message: 'ERROR' }
           })
           : ({ message: 'NO USER' })

--- a/src/components/Router/index.jsx
+++ b/src/components/Router/index.jsx
@@ -47,13 +47,20 @@ const Router = (props) => {
         }
 
         return isAuthRoutes
-          ? fetcher(authConfig).catch((e) => {
-            console.log(e)
-            setTimeout(() => {
-              window.location.href = loginUrl
-            }, 3000)
-            return { message: 'ERROR' }
-          })
+          ? fetcher(authConfig)
+            .then((res) => {
+              if (res.message === 'Unauthorized') {
+                throw new Error(res.message)
+              }
+              return res
+            })
+            .catch((e) => {
+              console.log(e)
+              window.location.href = (
+                window.location.href.replace(window.location.pathname, `${window.APP_BASENAME}/${loginUrl}`)
+              )
+              return { message: 'ERROR' }
+            })
           : ({ message: 'NO USER' })
       },
       children: withErrorElement([

--- a/src/mock/auth/checkAuthorize.js
+++ b/src/mock/auth/checkAuthorize.js
@@ -1,3 +1,4 @@
+import { get, isEmpty } from 'lodash-es'
 import getApiPrefix from '../../utils/getApiPrefix'
 
 export default [
@@ -5,7 +6,11 @@ export default [
     url: `${getApiPrefix()}/checkAuthorize`,
     method: 'get',
     timeout: 1500,
-    response: () => {
+    response: (response) => {
+      const authorization = get(response, 'headers.authorization')
+      if (isEmpty(authorization)) {
+        return { message: 'Unauthorized' }
+      }
       return { message: 'MOCK USER' }
     }
   }

--- a/src/sites/index.jsx
+++ b/src/sites/index.jsx
@@ -4,7 +4,13 @@ import Root from '../components/Root'
 
 const links = flow(
   () => keys(import.meta.glob('./**/index.html')),
-  (paths) => paths.filter((path) => path !== './index.html'),
+  (paths) => paths.filter((path) => {
+    return (
+      path !== './index.html' &&
+      // login 只有在 mock 環境露出
+      (window.IS_MOCK ? true : !path.includes('./login'))
+    )
+  }),
   (filteredPaths) => filteredPaths.map((path) => path.replace('./', '/').replace('index.html', '')),
   (endpoints) => endpoints.map((endpoint) => ({ url: `${window.APP_BASENAME}${endpoint}`, name: endpoint.replace(/\//g, '') }))
 )()

--- a/src/sites/login/index.html
+++ b/src/sites/login/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" sizes="32x32" href="../../favicon.ico">
+    <title>CWA SHOP</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="index.jsx"></script>
+  </body>
+</html>

--- a/src/sites/login/index.jsx
+++ b/src/sites/login/index.jsx
@@ -1,0 +1,13 @@
+import ReactDOM from 'react-dom/client'
+import Router from '../../components/Router'
+import getRoutes from '../../components/Router/getRoutes'
+import Root from '../../components/Root'
+
+const pages = import.meta.glob('./pages/**/index.jsx')
+const dynamicRoutes = getRoutes(pages)
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <Root>
+    <Router routes={dynamicRoutes} basename='/login' isAuthRoutes={false} />
+  </Root>
+)

--- a/src/sites/login/pages/index.jsx
+++ b/src/sites/login/pages/index.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Formik, Field, Form } from 'formik'
 import qs from 'query-string'
 
@@ -7,6 +8,10 @@ const FORM = {
 }
 
 const Login = () => {
+  useEffect(() => {
+    [FORM.TOKEN_TYPE, FORM.ACCESS_TOKEN].map((key) => window.localStorage.removeItem(key))
+  }, [])
+
   return (
     <div className='hero min-h-screen bg-base-200'>
       <div className='hero-content flex-col lg:flex-row-reverse'>

--- a/src/sites/login/pages/index.jsx
+++ b/src/sites/login/pages/index.jsx
@@ -1,0 +1,51 @@
+import { Formik, Field, Form } from 'formik'
+import qs from 'query-string'
+
+const FORM = {
+  TOKEN_TYPE: 'token_type',
+  ACCESS_TOKEN: 'access_token'
+}
+
+const Login = () => {
+  return (
+    <div className='hero min-h-screen bg-base-200'>
+      <div className='hero-content flex-col lg:flex-row-reverse'>
+        <div className='card w-full max-w-sm shrink-0 bg-base-100 shadow-2xl'>
+          <Formik
+            initialValues={{
+              [FORM.TOKEN_TYPE]: 'Bearer',
+              [FORM.ACCESS_TOKEN]: 'mock-access-token_123'
+            }}
+          >
+            {({ values }) => (
+              <Form className='card-body'>
+                <div className='form-control'>
+                  <label className='label'>
+                    <span className='label-text'>Token Type</span>
+                  </label>
+                  <Field name={FORM.TOKEN_TYPE} className='input input-bordered' required />
+                </div>
+                <div className='form-control'>
+                  <label className='label'>
+                    <span className='label-text'>Access Token</span>
+                  </label>
+                  <Field name={FORM.ACCESS_TOKEN} className='input input-bordered' required />
+                </div>
+                <div className='form-control mt-6'>
+                  <a
+                    className='btn btn-primary'
+                    href={window.location.href.replace(window.location.pathname, `${window.APP_BASENAME}/external/?${qs.stringify(values)}`)}
+                  >
+                    Login
+                  </a>
+                </div>
+              </Form>
+            )}
+          </Formik>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Login

--- a/src/utils/fetcher.js
+++ b/src/utils/fetcher.js
@@ -43,7 +43,8 @@ const fetcher = async (config = {}, triggerArgs = {}) => {
     .catch((e) => {
       const isMockAwsApi = (window.IS_MOCK_AWS_API && key.startsWith(window.AWS_HOST_PREFIX))
       if (!window.IS_MOCK && !isMockAwsApi) {
-        throw e
+        console.log(e)
+        throw new Error('發生錯誤')
       }
 
       console.log(

--- a/src/utils/fetcher.js
+++ b/src/utils/fetcher.js
@@ -1,10 +1,70 @@
 import { isEmpty } from 'lodash-es'
 import mockFetcher from './mockFetcher'
+import getSearchValuesFromUrl from './getSearchValuesFromUrl'
+
+const TOKEN_KEY = {
+  TOKEN_TYPE: 'token_type',
+  ACCESS_TOKEN: 'access_token'
+}
+
+let TMP_TOKEN = {}
+
+const TOKEN_KEYS = [TOKEN_KEY.TOKEN_TYPE, TOKEN_KEY.ACCESS_TOKEN]
+
+const getAuthorization = () => {
+  let Authorization = {}
+  const [
+    tokenTypeFromStorage, accessTokenFromStorage
+  ] = TOKEN_KEYS.map((key) => window.localStorage.getItem(key))
+  const [tokenTypeFromUrl, accessTokenFromUrl] = getSearchValuesFromUrl(TOKEN_KEYS)
+  const isTempTokenExist = !isEmpty(TMP_TOKEN)
+  const isStorageTokenExist = !!(tokenTypeFromStorage && accessTokenFromStorage)
+  const isUrlSearchTokenExist = !!(tokenTypeFromUrl && accessTokenFromUrl)
+  switch (true) {
+    case isTempTokenExist: {
+      Authorization = TMP_TOKEN
+      break
+    }
+    case isStorageTokenExist: {
+      Authorization = {
+        [TOKEN_KEY.TOKEN_TYPE]: tokenTypeFromStorage,
+        [TOKEN_KEY.ACCESS_TOKEN]: accessTokenFromStorage
+      }
+      TOKEN_KEYS.map((key) => window.localStorage.removeItem(key))
+      break
+    }
+    case isUrlSearchTokenExist: {
+      Authorization = {
+        [TOKEN_KEY.TOKEN_TYPE]: tokenTypeFromUrl,
+        [TOKEN_KEY.ACCESS_TOKEN]: accessTokenFromUrl
+      }
+      window.history.replaceState(null, '', window.location.pathname)
+      break
+    }
+    default:
+      break
+  }
+
+  if (isEmpty(Authorization)) {
+    return {}
+  }
+
+  TMP_TOKEN = Authorization
+  return {
+    Authorization: `${Authorization[TOKEN_KEY.TOKEN_TYPE]} ${Authorization[TOKEN_KEY.ACCESS_TOKEN]}`
+  }
+}
+
+const beforeUnloadHandler = () => {
+  if (!isEmpty(TMP_TOKEN)) {
+    TOKEN_KEYS.map((key) => window.localStorage.setItem(key, TMP_TOKEN[key]))
+  }
+}
+window.addEventListener('beforeunload', beforeUnloadHandler)
 
 const fetcher = async (config = {}, triggerArgs = {}) => {
-  const urlSearch = new URLSearchParams(window.location.search)
-  const [tokenType, accessToken] = ['token_type', 'access_token'].map((key) => urlSearch.get(key))
-  const isForceDisableMock = urlSearch.get('MOCK') === '0'
+  const [forceMock] = getSearchValuesFromUrl(['MOCK'])
+  const isForceDisableMock = forceMock === '0'
   const { arg: { url: keyFromTrigger = '', ...body } = {} } = triggerArgs
   const { host = '', url: keyFromGet = '', options = {} } = config
   const { header = {}, ...restOptions } = options
@@ -13,10 +73,11 @@ const fetcher = async (config = {}, triggerArgs = {}) => {
   const isHttpRequest = host.startsWith('http')
   const isAwsApi = key.startsWith(window.AWS_HOST_PREFIX)
   const isGetRequest = isEmpty(body)
+  const authorization = getAuthorization()
   const newOptions = {
     headers: new Headers({
       'Content-type': 'application/json; charset=UTF-8',
-      Authorization: `${tokenType} ${accessToken}`,
+      ...authorization,
       ...header
     }),
     ...(!isGetRequest && { body: JSON.stringify(body) }),

--- a/src/utils/getSearchValuesFromUrl.js
+++ b/src/utils/getSearchValuesFromUrl.js
@@ -1,0 +1,7 @@
+const getSearchValuesFromUrl = (keys) => {
+  const urlSearch = new URLSearchParams(window.location.search)
+  const values = keys.map((key) => urlSearch.get(key))
+  return values
+}
+
+export default getSearchValuesFromUrl


### PR DESCRIPTION
1. add production login logout url
1. add dev env `/login` page
1. login strategy
    - get tokens from query string & clear query string & store into tmp variable
    - get tokens from local storage & clear local storage & store into tmp variable
    - get `Unauthorized` redirect to logout
1. logout strategy
    - production get to logout url
    - dev clear local storage
1. ref: https://github.com/sky172839465/cwa-shop/pull/49