### PR TITLE
feat: form action add queue, disable on uploading and refresh

### DIFF
--- a/src/components/Dropzone/index.jsx
+++ b/src/components/Dropzone/index.jsx
@@ -30,6 +30,7 @@ const Dropzone = (props) => {
     customPreviewSize,
     isSelectFolder = false,
     isShowPreview = true,
+    onStart = () => {},
     onFinish = () => {}
   } = props
   const [isPending, setIsPending] = useState(false)
@@ -45,6 +46,7 @@ const Dropzone = (props) => {
   }
 
   const onDrop = useCallback(async (defaultAcceptedFiles, defaultFileRejections) => {
+    onStart()
     setIsPending(true)
     const acceptFilesMap = keyBy(files, 'name')
     const acceptedFiles = filter(defaultAcceptedFiles, (acceptedFile) => {
@@ -140,7 +142,7 @@ const Dropzone = (props) => {
     setFieldValue(name, allFiles)
     setIsPending(false)
     onFinish(allFiles)
-  }, [files, rejectField, name, maxSize, accept, isSelectFolder, setFieldValue, onFinish])
+  }, [files, rejectField, name, maxSize, accept, isSelectFolder, setFieldValue, onFinish, onStart])
 
   const {
     getRootProps,
@@ -155,6 +157,11 @@ const Dropzone = (props) => {
     setFieldValue(name, newFiles)
   }
 
+  const onRemoveFileByFileName = (fileName) => {
+    const newFiles = files.filter((file) => file.name !== fileName)
+    setFieldValue(name, newFiles)
+  }
+
   const open = () => {
     const { ref } = getInputProps()
     ref.current.click()
@@ -163,6 +170,7 @@ const Dropzone = (props) => {
   useImperativeHandle(dropzoneRef, () => {
     return {
       removeFile: (index) => onRemoveFile(index)(),
+      removeFileByFileName: (fileName) => onRemoveFileByFileName(fileName),
       setAcceptedFiles: (defaultFiles) => setFieldValue(name, defaultFiles),
       getAcceptedFiles: () => files
     }

--- a/src/hooks/useRecognition.js
+++ b/src/hooks/useRecognition.js
@@ -82,6 +82,7 @@ const useRecognition = (file, queue, controller, onUpdate) => {
         setIsLoading(false)
         setError(uploadS3Error)
         setStatus('fail')
+        onUpdate({}, false)
         return
       }
 
@@ -102,6 +103,7 @@ const useRecognition = (file, queue, controller, onUpdate) => {
       if (videoRecognitionError.message !== 'pending') {
         setIsRecognitionError(true)
       }
+      onUpdate({}, false)
       return
     }
 

--- a/src/sites/demo/pages/batch/EditModal.jsx
+++ b/src/sites/demo/pages/batch/EditModal.jsx
@@ -1,6 +1,8 @@
 import { useRef, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Formik, Field, Form } from 'formik'
+import {
+  Formik, Field, Form, useFormikContext
+} from 'formik'
 import clx from 'classnames'
 import {
   flow, get, isEmpty, isNull, map, pick
@@ -41,11 +43,13 @@ const EditModal = (props) => {
   const {
     modalRef, editItem, onClose, onUpdated
   } = props
+  const rootFormProps = useFormikContext()
   const [isUpdated, setIsUpdated] = useState(false)
   const dropzoneRef = useRef()
   const { t, i18n } = useTranslation()
   const { fishTypes, isLoading } = useFishTypes(i18n.language, false)
   const initFormData = get(editItem, 'data', {})
+  const fileName = get(editItem, 'item.name', {})
   const {
     itemSerial,
     originItemImage = '',
@@ -80,7 +84,10 @@ const EditModal = (props) => {
       ...pick(formValues, [FORM.FISH_TYPE, FORM.ITEM_SERIAL, FORM.ITEM_VIDEO]),
       [FORM.ITEM_IMAGES]: convertedItemImages
     }
-    onUpdated(`${editItem.field}.${FORM_ITEM.RECOGNITION_DATA}`, updateFormValues)
+    onUpdated(rootFormProps)(fileName, {
+      [FORM_ITEM.IS_UPLOADED]: true,
+      [FORM_ITEM.RECOGNITION_DATA]: updateFormValues
+    })
     modalRef.current.close()
   }
 

--- a/src/sites/demo/pages/batch/Table.jsx
+++ b/src/sites/demo/pages/batch/Table.jsx
@@ -1,16 +1,31 @@
-import { get } from 'lodash-es'
+import { useEffect, useState } from 'react'
+import { useFormikContext } from 'formik'
+import { get, isUndefined, some } from 'lodash-es'
 import useQueue from '../../../../hooks/useQueue'
+import { FORM, FORM_ITEM } from './constants'
 import TableRow from './TableRow'
 
 const Table = (props) => {
   const {
-    field,
-    data,
     onRemove,
     onEdit,
-    onUpdated
+    onUpdated,
+    isCalculating
   } = props
   const { queue, controller } = useQueue()
+  const { values } = useFormikContext()
+  const data = get(values, FORM.ROWS)
+  const [isUploading, setIsUploading] = useState(false)
+  const isDisabledAction = isUploading || isCalculating
+
+  useEffect(() => {
+    const nextIsUploading = some(data, (row) => isUndefined(row[FORM_ITEM.RECOGNITION_DATA]))
+    if (isUploading === nextIsUploading) {
+      return
+    }
+
+    setIsUploading(nextIsUploading)
+  }, [data, isUploading])
 
   return (
     <div className='mt-4 overflow-x-auto'>
@@ -25,19 +40,23 @@ const Table = (props) => {
           </tr>
         </thead>
         <tbody>
-          {data.map((item, index) => (
-            <TableRow
-              field={`${field}.${index}`}
-              item={item}
-              index={index}
-              key={get(item, 'uploadFile.name')}
-              onRemove={onRemove}
-              onEdit={onEdit}
-              onUpdated={onUpdated}
-              queue={queue}
-              controller={controller}
-            />
-          ))}
+          {data.map((item, index) => {
+            const fileName = get(item, 'uploadFile.name')
+            return (
+              <TableRow
+                key={fileName}
+                fileName={fileName}
+                item={item}
+                index={index}
+                onRemove={onRemove}
+                onEdit={onEdit}
+                onUpdated={onUpdated}
+                queue={queue}
+                controller={controller}
+                isDisabledAction={isDisabledAction}
+              />
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/src/sites/demo/pages/batch/TableRow.jsx
+++ b/src/sites/demo/pages/batch/TableRow.jsx
@@ -1,3 +1,4 @@
+import { useFormikContext } from 'formik'
 import {
   MdEdit, MdDelete, MdCheckCircle, MdError, MdCloudUpload, MdOutlineRefresh
 } from 'react-icons/md'
@@ -43,9 +44,10 @@ const RowIcon = (props) => {
 
 const TableRow = (props) => {
   const {
-    item, field, index, onRemove, onEdit, onUpdated,
-    queue, controller
+    item, fileName, index, onRemove, onEdit, onUpdated,
+    queue, controller, isDisabledAction
   } = props
+  const formProps = useFormikContext()
   const { i18n } = useTranslation()
   const { fishTypeMap } = useFishTypes(i18n.language, false)
   const {
@@ -54,8 +56,7 @@ const TableRow = (props) => {
     item[FORM_ITEM.UPLOAD_FILE],
     queue,
     controller,
-    (newData, isSuccess) => onUpdated(field, {
-      ...item,
+    (newData, isSuccess) => onUpdated(formProps)(fileName, {
       [FORM_ITEM.RECOGNITION_DATA]: newData,
       [FORM_ITEM.IS_UPLOADED]: isSuccess
     })
@@ -68,6 +69,14 @@ const TableRow = (props) => {
       ? 'edit'
       : get(error, 'message', toString(error))
   const isPending = (errorMessage === 'pending')
+
+  const onRefresh = async () => {
+    await onUpdated(formProps)(fileName, {
+      [FORM_ITEM.RECOGNITION_DATA]: undefined,
+      [FORM_ITEM.IS_UPLOADED]: false
+    })
+    trigger()
+  }
 
   return (
     <tr>
@@ -133,7 +142,8 @@ const TableRow = (props) => {
               className={clx('btn btn-square', { invisible: isNoVideo })}
               disabled={isLoading}
               onClick={() => onEdit({
-                index, item: item[FORM_ITEM.UPLOAD_FILE], data: formData, field
+                item: item[FORM_ITEM.UPLOAD_FILE],
+                data: formData
               })}
             >
               <MdEdit size='1.5em' />
@@ -145,7 +155,7 @@ const TableRow = (props) => {
               data-role='triggerRefresh'
               className={clx('btn btn-square', { invisible: isNoVideo })}
               disabled={isLoading}
-              onClick={() => trigger()}
+              onClick={onRefresh}
             >
               <MdOutlineRefresh size='1.5em' />
             </button>
@@ -153,8 +163,8 @@ const TableRow = (props) => {
           <button
             type='button'
             className='btn btn-square'
-            disabled={isLoading}
-            onClick={() => onRemove(index)}
+            disabled={isLoading || isDisabledAction}
+            onClick={() => onRemove(formProps)(fileName)}
           >
             <MdDelete size='1.5em' />
           </button>

--- a/src/sites/demo/pages/batch/TableRow.jsx
+++ b/src/sites/demo/pages/batch/TableRow.jsx
@@ -135,7 +135,7 @@ const TableRow = (props) => {
         </>
       )}
       <th>
-        <div className='space-x-4 text-right max-lg:w-32'>
+        <div className='w-32 space-x-4 text-right'>
           {(!state.isError || isRecognitionError) && (
             <button
               type='button'


### PR DESCRIPTION
1. add queue prevent complex form action conflict
1. disable row action on
    <img width="1128" alt="image" src="https://github.com/sky172839465/cwa-shop/assets/9082423/27bc66f7-9dd1-4aff-a3a6-053380872bc9">
    - some row not recognized / uploaded yet
    - some row trigger refresh